### PR TITLE
Add support for advanced meta query ordering

### DIFF
--- a/termmeta.php
+++ b/termmeta.php
@@ -171,6 +171,28 @@ function hm_add_term_meta_query_support( $pieces, $taxonomies, $args ) {
 	if ( ! $sql ) {
 		return $pieces;
 	}
+	
+	// Support advanced meta ordering introduced in WP 4.2
+	if ( $args['orderby'] && method_exists( $meta_query, 'get_clauses' ) ) {
+		$orderby = $args['orderby'];
+		$meta_clauses = $meta_query->get_clauses();
+		
+		$reserved_terms = array(
+			'id',
+			'count',
+			'name',
+			'slug',
+			'term_group',
+			'description',
+			'none',
+		);
+		
+		if ( ! in_array( $orderby, $reserved_terms ) && array_key_exists( $orderby, $meta_clauses ) ) {
+			$meta_clause = $meta_clauses[ $orderby ];
+			$orderby_clause = "CAST({$meta_clause['alias']}.meta_value AS {$meta_clause['cast']})";
+			$pieces['orderby'] = "ORDER BY $orderby_clause";
+		}
+	}
 
 	$pieces['join'] .= $sql['join'];
 	$pieces['where'] .= $sql['where'];


### PR DESCRIPTION
In WP 4.2 advanced ordering for `WP_Meta_Query` was introduced. This adds support if it's available.

Refer: https://make.wordpress.org/core/2015/03/30/query-improvements-in-wp-4-2-orderby-and-meta_query/
